### PR TITLE
Versions bumped

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.curityVersion>6.7.0</project.curityVersion>
+        <project.curityVersion>7.0.0</project.curityVersion>
         <project.slf4jVersion>1.7.30</project.slf4jVersion>
-        <kotlin.version>1.5.32</kotlin.version>
+        <kotlin.version>1.6.10</kotlin.version>
     </properties>
 
     <build>
@@ -52,7 +52,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <jvmTarget>11</jvmTarget>
+                    <jvmTarget>17</jvmTarget>
                 </configuration>
             </plugin>
         </plugins>
@@ -84,9 +84,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>6.2.0.CR1</version>
+            <version>7.0.3.Final</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <project.curityVersion>7.0.0</project.curityVersion>
         <project.slf4jVersion>1.7.36</project.slf4jVersion>
         <kotlin.version>1.6.10</kotlin.version>
+        <maven.surefireVersion>3.0.0-M7</maven.surefireVersion>
     </properties>
 
     <build>
@@ -43,17 +44,26 @@
                     <execution>
                         <id>compile</id>
                         <phase>compile</phase>
-                        <goals><goal>compile</goal></goals>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
                     </execution>
                     <execution>
                         <id>test-compile</id>
                         <phase>test-compile</phase>
-                        <goals><goal>test-compile</goal></goals>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
                     </execution>
                 </executions>
                 <configuration>
                     <jvmTarget>17</jvmTarget>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefireVersion}</version>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.curityVersion>7.0.0</project.curityVersion>
-        <project.slf4jVersion>1.7.30</project.slf4jVersion>
+        <project.slf4jVersion>1.7.36</project.slf4jVersion>
         <kotlin.version>1.6.10</kotlin.version>
     </properties>
 
@@ -78,9 +78,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-            <version>2.0.1.Final</version>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>3.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/kotlin/io/curity/identityserver/plugins/action/identitypicker/IdentityPickerRequestHandler.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugins/action/identitypicker/IdentityPickerRequestHandler.kt
@@ -17,7 +17,7 @@
 
 package io.curity.identityserver.plugins.action.identitypicker
 
-import org.hibernate.validator.constraints.NotBlank
+import javax.validation.constraints.NotBlank
 import se.curity.identityserver.sdk.attribute.Attribute
 import se.curity.identityserver.sdk.attribute.ListAttributeValue
 import se.curity.identityserver.sdk.attribute.MapAttributeValue

--- a/src/main/kotlin/io/curity/identityserver/plugins/action/identitypicker/IdentityPickerRequestHandler.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugins/action/identitypicker/IdentityPickerRequestHandler.kt
@@ -17,7 +17,9 @@
 
 package io.curity.identityserver.plugins.action.identitypicker
 
-import javax.validation.constraints.NotBlank
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 import se.curity.identityserver.sdk.attribute.Attribute
 import se.curity.identityserver.sdk.attribute.ListAttributeValue
 import se.curity.identityserver.sdk.attribute.MapAttributeValue
@@ -29,8 +31,6 @@ import se.curity.identityserver.sdk.web.Response
 import se.curity.identityserver.sdk.web.ResponseModel.templateResponseModel
 import java.lang.RuntimeException
 import java.util.Optional
-import javax.validation.Valid
-import javax.validation.constraints.NotNull
 
 private const val IDENTITIES_TEMPLATE_KEY = "_identities"
 


### PR DESCRIPTION
Curity SDK -> 7.0.0
Java -> 17
Kotlin -> 1.6.10
org.hibernate.validator:hibernate-validator -> 7.0.3.Final
Replaced deprecated NotBlank annotation with javax.validation.constraints.NotBlank